### PR TITLE
Making sure project runs with Jekyll 3.4.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,3 +38,6 @@ paginate: 3
 
 # Exclude metadata and development time dependencies (like Grunt plugins)
 exclude: [README.markdown, package.json, grunt.js, Gruntfile.js, Gruntfile.coffee, node_modules]
+
+# Listing gems used by project
+gems: [jekyll-paginate]


### PR DESCRIPTION
Fixing issue mentioned in: #6

This way your project will run just fine with the latest Jenkins.